### PR TITLE
Fixed non-idempotent test in ShortUrlDaoTest by creating unique short url

### DIFF
--- a/src/test/java/com/app/mvc/dao/ShortUrlDaoTest.java
+++ b/src/test/java/com/app/mvc/dao/ShortUrlDaoTest.java
@@ -4,6 +4,7 @@ import com.app.mvc.shortUrl.ShortUrl;
 import com.app.mvc.shortUrl.ShortUrlDao;
 import org.junit.Test;
 
+import java.util.Date;
 import javax.annotation.Resource;
 
 /**
@@ -16,7 +17,8 @@ public class ShortUrlDaoTest extends BaseJunitTest {
 
     @Test
     public void testSave() {
-        ShortUrl shortUrl = ShortUrl.builder().origin("test").current("test").status(1).build();
+        String now = new Date().toString();
+        ShortUrl shortUrl = ShortUrl.builder().origin("test" + now).current("test" + now).status(1).build();
         shortUrlDao.save(shortUrl);
     }
 }


### PR DESCRIPTION
- 该公关通过实施第二个拟议解决方案修复了https://github.com/kanwangzjm/funiture/issues/50中提到的问题
- 使用当前时间戳将确保“ShortUrl”对所有测试运行都是独一无二的。